### PR TITLE
Automatic update of 4 packages

### DIFF
--- a/GroupService/GroupService.AzureFunction/GroupService.AzureFunction.csproj
+++ b/GroupService/GroupService.AzureFunction/GroupService.AzureFunction.csproj
@@ -6,7 +6,7 @@
 	<ItemGroup>
 		<PackageReference Include="AzureFunctions.Extensions.Swashbuckle" Version="1.4.4" />
 		<PackageReference Include="HelpMyStreet.Cache" Version="1.1.346" />
-		<PackageReference Include="HelpMyStreet.Contracts" Version="1.1.346" />
+		<PackageReference Include="HelpMyStreet.Contracts" Version="1.1.379" />
 		<PackageReference Include="HelpMyStreet.PostcodeCoordinates.EF" Version="1.1.346" />
 		<PackageReference Include="HelpMyStreet.Utils" Version="1.1.379" />
 		<PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.0.0" />

--- a/GroupService/GroupService.AzureFunction/GroupService.AzureFunction.csproj
+++ b/GroupService/GroupService.AzureFunction/GroupService.AzureFunction.csproj
@@ -8,7 +8,7 @@
 		<PackageReference Include="HelpMyStreet.Cache" Version="1.1.346" />
 		<PackageReference Include="HelpMyStreet.Contracts" Version="1.1.346" />
 		<PackageReference Include="HelpMyStreet.PostcodeCoordinates.EF" Version="1.1.346" />
-		<PackageReference Include="HelpMyStreet.Utils" Version="1.1.346" />
+		<PackageReference Include="HelpMyStreet.Utils" Version="1.1.379" />
 		<PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.0.0" />
 		<PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="7.0.0" />
 		<PackageReference Include="MediatR" Version="8.0.1" />

--- a/GroupService/GroupService.AzureFunction/GroupService.AzureFunction.csproj
+++ b/GroupService/GroupService.AzureFunction/GroupService.AzureFunction.csproj
@@ -5,7 +5,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="AzureFunctions.Extensions.Swashbuckle" Version="1.4.4" />
-		<PackageReference Include="HelpMyStreet.Cache" Version="1.1.346" />
+		<PackageReference Include="HelpMyStreet.Cache" Version="1.1.379" />
 		<PackageReference Include="HelpMyStreet.Contracts" Version="1.1.379" />
 		<PackageReference Include="HelpMyStreet.PostcodeCoordinates.EF" Version="1.1.346" />
 		<PackageReference Include="HelpMyStreet.Utils" Version="1.1.379" />

--- a/GroupService/GroupService.AzureFunction/GroupService.AzureFunction.csproj
+++ b/GroupService/GroupService.AzureFunction/GroupService.AzureFunction.csproj
@@ -7,7 +7,7 @@
 		<PackageReference Include="AzureFunctions.Extensions.Swashbuckle" Version="1.4.4" />
 		<PackageReference Include="HelpMyStreet.Cache" Version="1.1.379" />
 		<PackageReference Include="HelpMyStreet.Contracts" Version="1.1.379" />
-		<PackageReference Include="HelpMyStreet.PostcodeCoordinates.EF" Version="1.1.346" />
+		<PackageReference Include="HelpMyStreet.PostcodeCoordinates.EF" Version="1.1.379" />
 		<PackageReference Include="HelpMyStreet.Utils" Version="1.1.379" />
 		<PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.0.0" />
 		<PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="7.0.0" />

--- a/GroupService/GroupService.Core/GroupService.Core.csproj
+++ b/GroupService/GroupService.Core/GroupService.Core.csproj
@@ -6,7 +6,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="HelpMyStreet.Contracts" Version="1.1.346" />
-		<PackageReference Include="HelpMyStreet.Utils" Version="1.1.346" />
+		<PackageReference Include="HelpMyStreet.Utils" Version="1.1.379" />
 		<PackageReference Include="MediatR" Version="8.0.1" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="2.2.0" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />

--- a/GroupService/GroupService.Core/GroupService.Core.csproj
+++ b/GroupService/GroupService.Core/GroupService.Core.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="HelpMyStreet.Contracts" Version="1.1.346" />
+		<PackageReference Include="HelpMyStreet.Contracts" Version="1.1.379" />
 		<PackageReference Include="HelpMyStreet.Utils" Version="1.1.379" />
 		<PackageReference Include="MediatR" Version="8.0.1" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="2.2.0" />

--- a/GroupService/GroupService.Handlers/GroupService.Handlers.csproj
+++ b/GroupService/GroupService.Handlers/GroupService.Handlers.csproj
@@ -5,7 +5,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="HelpMyStreet.Contracts" Version="1.1.346" />
+		<PackageReference Include="HelpMyStreet.Contracts" Version="1.1.379" />
 		<PackageReference Include="HelpMyStreet.Utils" Version="1.1.379" />
 		<PackageReference Include="MediatR" Version="8.0.1" />
 		<PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="8.0.0" />

--- a/GroupService/GroupService.Handlers/GroupService.Handlers.csproj
+++ b/GroupService/GroupService.Handlers/GroupService.Handlers.csproj
@@ -6,7 +6,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="HelpMyStreet.Contracts" Version="1.1.346" />
-		<PackageReference Include="HelpMyStreet.Utils" Version="1.1.346" />
+		<PackageReference Include="HelpMyStreet.Utils" Version="1.1.379" />
 		<PackageReference Include="MediatR" Version="8.0.1" />
 		<PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="8.0.0" />
 	</ItemGroup>

--- a/GroupService/GroupService.Repo/GroupService.Repo.csproj
+++ b/GroupService/GroupService.Repo/GroupService.Repo.csproj
@@ -6,7 +6,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="AutoMapper" Version="9.0.0" />
-		<PackageReference Include="HelpMyStreet.Utils" Version="1.1.346" />
+		<PackageReference Include="HelpMyStreet.Utils" Version="1.1.379" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="2.2.6" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="2.2.6" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="2.2.6" />


### PR DESCRIPTION
4 packages were updated in 4 projects:
`HelpMyStreet.Utils`, `HelpMyStreet.Contracts`, `HelpMyStreet.Cache`, `HelpMyStreet.PostcodeCoordinates.EF`
<details>
<summary>Details of updated packages</summary>

NuKeeper has generated a patch update of `HelpMyStreet.Utils` to `1.1.379` from `1.1.346`
`HelpMyStreet.Utils 1.1.379` was published at `2020-09-23T13:56:34Z`, 2 hours ago

4 project updates:
Updated `GroupService\GroupService.AzureFunction\GroupService.AzureFunction.csproj` to `HelpMyStreet.Utils` `1.1.379` from `1.1.346`
Updated `GroupService\GroupService.Core\GroupService.Core.csproj` to `HelpMyStreet.Utils` `1.1.379` from `1.1.346`
Updated `GroupService\GroupService.Handlers\GroupService.Handlers.csproj` to `HelpMyStreet.Utils` `1.1.379` from `1.1.346`
Updated `GroupService\GroupService.Repo\GroupService.Repo.csproj` to `HelpMyStreet.Utils` `1.1.379` from `1.1.346`

NuKeeper has generated a patch update of `HelpMyStreet.Contracts` to `1.1.379` from `1.1.346`
`HelpMyStreet.Contracts 1.1.379` was published at `2020-09-23T13:56:26Z`, 2 hours ago

3 project updates:
Updated `GroupService\GroupService.AzureFunction\GroupService.AzureFunction.csproj` to `HelpMyStreet.Contracts` `1.1.379` from `1.1.346`
Updated `GroupService\GroupService.Core\GroupService.Core.csproj` to `HelpMyStreet.Contracts` `1.1.379` from `1.1.346`
Updated `GroupService\GroupService.Handlers\GroupService.Handlers.csproj` to `HelpMyStreet.Contracts` `1.1.379` from `1.1.346`

NuKeeper has generated a patch update of `HelpMyStreet.Cache` to `1.1.379` from `1.1.346`
`HelpMyStreet.Cache 1.1.379` was published at `2020-09-23T13:56:22Z`, 2 hours ago

1 project update:
Updated `GroupService\GroupService.AzureFunction\GroupService.AzureFunction.csproj` to `HelpMyStreet.Cache` `1.1.379` from `1.1.346`

NuKeeper has generated a patch update of `HelpMyStreet.PostcodeCoordinates.EF` to `1.1.379` from `1.1.346`
`HelpMyStreet.PostcodeCoordinates.EF 1.1.379` was published at `2020-09-23T13:56:30Z`, 2 hours ago

1 project update:
Updated `GroupService\GroupService.AzureFunction\GroupService.AzureFunction.csproj` to `HelpMyStreet.PostcodeCoordinates.EF` `1.1.379` from `1.1.346`

</details>


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
